### PR TITLE
Updated Alpino version

### DIFF
--- a/cfg/component_versions
+++ b/cfg/component_versions
@@ -1,18 +1,18 @@
 #!/bin/sh
 #
 # Component versions for the VU-RM-Pipeline
-# 
+#
 # Author: Sophie Arnoult
 # Date:   03/04/19
-#---------------------------------------------------- 
+#----------------------------------------------------
 
 # GitHub commit numbers
 
 v_text2naf=fa4178d
-v_morphosyntactic_parser_nl=85b7603 
-v_ixa_pipe_ned=062a983 
+v_morphosyntactic_parser_nl=85b7603
+v_ixa_pipe_ned=062a983
 v_vua_resources=ef75f30
-v_svm_wsd=8bb5319 
+v_svm_wsd=8bb5319
 v_vuheideltimewrapper=3762c0e
 v_vua_srl_nl=23a18eb
 v_vua_srl_dutch_nominal_events=28b9cff
@@ -23,6 +23,6 @@ v_eventcoreference=3d4b32c
 
 # Other sources
 
-v_alpino=Alpino-x86_64-Linux-glibc-2.23-21514-sicstus
+v_alpino=Alpino-x86_64-Linux-glibc-2.23-21768-sicstus
 v_ixa_pipes=1.1.1
 v_dbpedia_spotlight=0.7.1


### PR DESCRIPTION
The Alpino version in this repository is no longer available for download. I updated the version.
It could also be changed to 'latest' but then there is no record of what version was used.

(I see that there's also some removing of trailing whitespaces in this pull request, hope that's ok).

