### PR TITLE
fix broken docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-slim-stretch
 
 WORKDIR /vurm
 RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 \

--- a/cfg/component_versions
+++ b/cfg/component_versions
@@ -22,6 +22,6 @@ v_ontotagger=c3796c5
 v_eventcoreference=f1de443
 
 # Other sources
-v_alpino=Alpino-x86_64-Linux-glibc-2.23-git116-sicstus
+v_alpino=Alpino-x86_64-Linux-glibc-2.23-git167-sicstus
 v_ixa_pipes=1.1.1
 v_dbpedia_spotlight=0.7.1


### PR DESCRIPTION
Dear all,

There are two issues with the most recent docker: 

1. python:3.6-slim moved to use debian:buster-slim which no longer has openjdk-8-jdk.
2. there was an error in the binary distro of Alpino which has been fixed by GJ.

This PR fixes both issues by using  python:3.6-slim-stretch and the new version of Alpino